### PR TITLE
Use docco programmatically instead of relying on global binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
   },
   "dependencies": {
     "grunt": "~0.3.9",
-    "docco": "0.3.0"
+    "docco": "~0.4.0"
   },
   "devDependencies": {
-    "grunt": "~0.3.9"
+    "grunt": "~0.3.9",
+    "rimraf": "~2.0.2"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/docco.js
+++ b/tasks/docco.js
@@ -6,16 +6,29 @@
 
 module.exports = function(grunt) {
 
-	// ### TASKS
-	grunt.registerMultiTask('docco', 'Docco processor.', function() {
-		var done = this.async();
-		var src = grunt.file.expandFiles(this.file.src);
-		grunt.utils.spawn({
-			cmd: "docco",
-			args: src
-		}, function(err, result, code){
-			grunt.log.writeln("Doccoed [" + src.join(", ") + "]; " + err ? err : "(No errors)" + "\n" + result + " " + code);
-			done();
-		});
-	});
+  var docco = require('docco');
+
+
+  // ### TASKS
+  grunt.registerMultiTask('docco', 'Docco processor.', function() {
+    var options, tmp;
+
+    tmp = grunt.config(['docco', this.target, 'options']);
+    if (typeof tmp === 'object') {
+      grunt.verbose.writeln('Using "' + this.target + '" Docco options.');
+      options = tmp;
+    } else {
+      grunt.verbose.writeln('Using master Docco options.');
+      options = grunt.config('jshint.options');
+    }
+    grunt.verbose.writeflags(options, 'Options');
+
+    var done = this.async();
+    var src = grunt.file.expandFiles(this.file.src);
+
+    docco.document(src, options, function(err, result, code){
+      grunt.log.writeln("Doccoed [" + src.join(", ") + "]; " + err ? err : "(No errors)" + "\n" + result + " " + code);
+      done();
+    });
+  });
 };

--- a/test/docco_test.js
+++ b/test/docco_test.js
@@ -9,7 +9,7 @@ exports.docco = {
      var html = grunt.file.read("docs/docco.html");
 
      test.expect(2);
-     test.equal(css.length, 7101, "Should create CSS.");
+     test.equal(css.length, 7207, "Should create CSS.");
      test.equal(html.length, 1017,"Should create HTML.")
      test.done();
 


### PR DESCRIPTION
Prior to this commit, you needed to have `docco` installed as a global module, or you would see this error (despite the task succeeding):

```
execvp(): No such file or directory
```

Since docco is included as a dependency and all, I figured that it would make sense to _use the module that's guaranteed to be installed_ rather than a binary that might not be.

So, feeling rather enterprising this evening, I rewrote the task, updated the tests and bumped the included docco module to the most current release.

Cheers! :shipit:
