### PR TITLE
Docco 0.6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,11 +11,11 @@ module.exports = function(grunt) {
         options: { output: "docs/" }
       },
       'custom-css-test': {
-          src: ['test/**/*.js'],
-          options: {
-              css: 'test/fixtures/custom.css',
-              output: 'docs/'
-          }
+        src: ['test/**/*.js'],
+        options: {
+            css: 'test/fixtures/custom.css',
+            output: 'docs/'
+        }
       }
     },
     jshint: {
@@ -38,6 +38,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['clean:tests', 'docco', 'nodeunit:tests']);
 
   // Default task.
-  grunt.registerTask('default', ['jshint', 'docco']);
+  grunt.registerTask('default', ['jshint', 'clean', 'docco']);
 
 };

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "docco": "~0.6.1",
-    "underscore": "~1.4.4"
+    "docco": "~0.6.3"
   },
   "devDependencies": {
     "rimraf": "~2.0.2",

--- a/tasks/docco.js
+++ b/tasks/docco.js
@@ -5,36 +5,10 @@
 // Licensed under the MIT license.
 
 "use strict";
-var _ = require('underscore'),
-    docco = require('docco');
-
-// Default configuration for `docco` which needs to be reapplied each time to ensure clean slate
-// for subsequent targets.
-var defaultConfig = {
-  layout: 'parallel',
-  output: 'docs/',
-  template: null,
-  css: null,
-  extension: null
-};
+var docco = require('docco');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('docco', 'Docco processor.', function() {
-    // Currently having to implement a dirty workaround for Docco 0.6's lack of functional API.
-    var options = this.options(),
-      args = ['node', 'docco'],
-      config = _.extend({}, defaultConfig, _.pick(options, _.keys(defaultConfig)));
-
-    // Building a mock array of CLI arguments to be parsed by internally by `docco`.
-    _.chain(config).keys().each(function(arg) {
-      if (!_.isNull(config[arg])) args.push('--' + arg, config[arg]);
-    });
-
-    // Appending source files to CLI arguments so `docco` runs them in bulk.
-    args = args.concat(this.filesSrc);
-
-    // Running `docco` as if it was called from a CLI. Since `docco` now works synchronously
-    // there's no need for async handling here.
-    docco.run(args);
+    docco.document(this.options({ args: this.filesSrc }), this.async());
   });
 };


### PR DESCRIPTION
This adds support for Docco 0.6, which was released yesterday in response to #13.

Unfortunately, for unknown reasons, Docco 0.6 has made the library virtually unusable through it's API (as it's removed most of it). I've managed to create a workaround for this but it's not really _clean_ so I've raised jashkenas/docco#156 to raise these concerns. That said; the workaround should allow us to deal with it in the mean time. If/when the API has been improved this workaround logic should be revisited to ensure we're doing things the best way possible.

Sadly, I'm currently blocked by _another_ issue which is preventing the tests from passing - or even completing. This is a bug with Docco and not this code, but until it has been fixed and these tests pass I would **_not accept**_ this pull request. Again, I've already created jashkenas/docco#160 to highlight this issue.

Finally, in order to successfully run `grunt` within the repository's root directory I've had to fix the lint task by updating it to use `grunt-contrib-jshint`, as is the new standard for Grunt 0.4+.
