### PR TITLE
Fixes parameters passed to  for 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-docco",
   "description": "Grunt Docco plugin.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/DavidSouther/grunt-docco",
   "author": {
     "name": "David Souther",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.0",
-    "docco": "~0.4.0",
+    "docco": "~0.6.0",
     "pygments": "~0.1.3"
   },
   "devDependencies": {

--- a/tasks/docco.js
+++ b/tasks/docco.js
@@ -13,9 +13,9 @@ module.exports = function(grunt) {
         fdone = 0,
         flength = this.files.length,
         done = this.async();
-
+    task.options({output: undefined});
     this.files.forEach(function(file) {
-      docco.document(file.src, task.options({ output: file.dest }), function(){
+      docco.document(task.options({args: file.src}), function(){
         if(++fdone === flength) done();
       });
     });


### PR DESCRIPTION
docco#document() (version 0.6.2) only accepts 2 arguments. This PR is intended in fixing how the parameters are passed from the task configuration to Docco.

Tested with a number of configurations, it has grunt-docco run easily with Docco 0.6.2.
## 

Originally, when requesting the grunt-docco package from NPM I continously had the error : `spawn error, ENOENT`dwa
