### PR TITLE
sources assigned to {}.args fixes #22

### DIFF
--- a/tasks/docco.js
+++ b/tasks/docco.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
         done = this.async();
 
     this.files.forEach(function(file) {
-      docco.document(file.src, task.options({ output: file.dest }), function(){
+      docco.document({ args: file.src }, task.options({ output: file.dest }), function(){
         if(++fdone === flength) done();
       });
     });


### PR DESCRIPTION
Docco expects the sources array to be on the args property of options.
