### PR TITLE
Experimental Docco Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 docs/
 node_modules/
 bin/
+
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "http://www.davidsouther.com"
   },
   "contributors": [
+    "Alasdair Mercer <mercer.alasdair@gmail.com>",
     "Asa Ayers <Asa.Ayers@Gmail.com>",
     "Brad Dougherty <me@brad.is>",
     "Diego Fernandez <diegof79@gmail.com>",
@@ -37,14 +38,14 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "docco": "~0.6.2"
+    "docco": "jashkenas/docco#a35da0022a"
   },
   "devDependencies": {
-    "rimraf": "~2.0.2",
+    "rimraf": "~2.2.5",
     "grunt": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-jshint": "~0.6.0"
+    "grunt-contrib-nodeunit": "~0.2.2",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "~0.8.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
This PR bumps various development dependencies but, more importantly, changes the Docco dependency to the following:

``` javascript
"dependencies": {
  "docco": "jashkenas/docco#a35da0022a"
}
```

This is the latest commit on the `master` branch of the Docco repository. It appears stable but it's worth noting that anything in that project's master branch is deemed "unstable" until released. This could mean that we may have to change this value from time to time if any key bugs are found and fixed but hopefully that will be rare and we can try to keep that to a minimum. I definitely don't recommend that we change this every time someone commits to `master` as that's probably more risky than letting commits accumulate, which is why I didn't just depend on the `master` branch itself (i.e. without specifying a commit hash).

If you have another commit you'd prefer (perhaps an older one), let me know and I can change it.

Eventually, this will be able to be replaced with a standard version number once the next version of Docco is released and we should try to do that as soon as it's available (I check regularly). For example:

``` javascript
"dependencies": {
  "docco": "~0.6.3"
}
```

One last note; I didn't bump the version of this module in the `package.json` file as I wasn't sure how you managed the publishing, so it's still **0.3.0**.
