### PR TITLE
Fix for highlight.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "docco": "jashkenas/docco#a35da0022a"
+    "docco": "jashkenas/docco#d6a7f7dc94"
   },
   "devDependencies": {
     "rimraf": "~2.2.5",


### PR DESCRIPTION
Recently the [highlight.js](https://github.com/isagalaev/highlight.js) library that is used by docco was updated with breaking changes. Although these changes were done in a major release, docco had the dependency marked in such a way that _all_ versions after 7.0.0 were allowed.

This issue has been fixed on the latest commit on the docco `master` branch, which I've updated our dependency to reference until the next official release of docco (or another breaking bug is discovered and fixed).

Please can you merge this in and bump the version of this plugin on npm.
