### PR TITLE
update docco version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "docco": "jashkenas/docco#d6a7f7dc94"
+    "docco": "~0.6.3"
   },
   "devDependencies": {
     "rimraf": "~2.2.5",


### PR DESCRIPTION
Since PR #35 we depend on a Docco version pulled from the git repository (jashkenas/docco#d6a7f7dc94) instead of npm, this causes npm install to fail on machines without git installed. 

Please can you merge this in and bump the version of this plugin on npm.
